### PR TITLE
PUI-18542: Update GitHub access token to be in headers

### DIFF
--- a/create-release.js
+++ b/create-release.js
@@ -23,7 +23,7 @@ class GithubReleaseCreator {
 
     http.makeFileUploadRequest(
       './release.tar.gz',
-      'https://uploads.github.com/repos/' + OWNER + '/' + REPO + '/releases/' + id + '/assets' + '&name=release.tar.gz',
+      'https://uploads.github.com/repos/' + OWNER + '/' + REPO + '/releases/' + id + '/assets' + '?name=release.tar.gz',
       GH_TOKEN
     ).then(res => {
 

--- a/create-release.js
+++ b/create-release.js
@@ -2,7 +2,6 @@ const TRAVIS_BRANCH_OR_TAG = process.argv[2];
 const GH_TOKEN = process.argv[3];
 const OWNER = process.argv[4];
 const REPO = process.argv[5];
-const TOKEN = '?access_token=' + GH_TOKEN;
 
 let HttpWrapper = require('./http-wrapper.js');
 let shell = require('shelljs');
@@ -10,21 +9,22 @@ let http = new HttpWrapper();
 let date = Date.now();
 
 class GithubReleaseCreator {
-  
+
   getReleaseData() {
     return JSON.stringify({
       tag_name: 'release-' + TRAVIS_BRANCH_OR_TAG + '-' + date,
       target_commitish: this.sha
     });
   }
-  
+
   uploadReleaseZip(id) {
 
     console.log('Uploading release...')
 
     http.makeFileUploadRequest(
       './release.tar.gz',
-      'https://uploads.github.com/repos/' + OWNER + '/' + REPO + '/releases/' + id + '/assets' + TOKEN + '&name=release.tar.gz'
+      'https://uploads.github.com/repos/' + OWNER + '/' + REPO + '/releases/' + id + '/assets' + '&name=release.tar.gz',
+      GH_TOKEN
     ).then(res => {
 
       console.log(res.body);
@@ -38,19 +38,20 @@ class GithubReleaseCreator {
 
     });
   }
-  
+
   createRelease() {
 
     console.log('Release data: ' + this.getReleaseData());
 
     http.makePostRequest(
-      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases' + TOKEN,
-      this.getReleaseData()
+      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases',
+      this.getReleaseData(),
+      GH_TOKEN
     ).then(res => {
 
       console.log(res.body);
       this.uploadReleaseZip(JSON.parse(res.body).id);
-  
+
     });
   }
 

--- a/download-release.js
+++ b/download-release.js
@@ -1,9 +1,8 @@
-const HEADERS = {headers: {'User-Agent': 'request'}};
+const HEADERS = {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/vnd.github.v3+json'}};
 const TRAVIS_BRANCH_OR_TAG = process.argv[2];
 const GH_TOKEN = process.argv[3];
 const OWNER = process.argv[4];
 const REPO = process.argv[5];
-const TOKEN = '?access_token=' + GH_TOKEN;
 let HttpWrapper = require('./http-wrapper.js');
 let _ = require('lodash');
 let shell = require('shelljs');
@@ -35,7 +34,7 @@ class GithubReleaseDownloader {
     console.log(`Branch/Tag: "${TRAVIS_BRANCH_OR_TAG}"`);
 
     http.makeGetRequest(
-      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases' + TOKEN,
+      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases',
       HEADERS
     ).then(res => {
       if (!res || !res.body) {
@@ -75,7 +74,7 @@ class GithubReleaseDownloader {
   download(assetId) {
     console.log('Downloading release...');
     shell.exec(
-      `wget -q --auth-no-challenge --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}?access_token=${GH_TOKEN} -O release.tar.gz`
+      `wget -q --header='Accept:application/octet-stream' --header='Authorization: token ${GH_TOKEN}' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} -O release.tar.gz`
     )
   }
 

--- a/download-release.js
+++ b/download-release.js
@@ -1,8 +1,8 @@
-const HEADERS = {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/vnd.github.v3+json'}};
 const TRAVIS_BRANCH_OR_TAG = process.argv[2];
 const GH_TOKEN = process.argv[3];
 const OWNER = process.argv[4];
 const REPO = process.argv[5];
+const HEADERS = {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/vnd.github.v3+json'}};
 let HttpWrapper = require('./http-wrapper.js');
 let _ = require('lodash');
 let shell = require('shelljs');

--- a/http-wrapper.js
+++ b/http-wrapper.js
@@ -14,12 +14,14 @@ class HttpWrapper {
     });
   }
 
-  makePostRequest(url, body, contentType) {
+  makePostRequest(url, body, contentType, token) {
     return new Promise((resolve, reject) => {
-      request.post({url: url, headers: {'User-Agent': 'request', 'Content-Type': contentType}, body: body}, (error, response) => {
-        if (error) {
-          reject(error);
-        }
+      request.post({
+        url: url,
+        headers: {'User-Agent': 'request', 'Content-Type': contentType, 'Authorization': `token ${token}`},
+        body: body
+      }, (error, response) => {
+        if (error) { reject(error); }
         resolve(response);
       });
     });
@@ -47,7 +49,7 @@ class HttpWrapper {
     });
   }
 
-  makeFileUploadRequest(file, url) {
+  makeFileUploadRequest(file, url, token) {
     return new Promise((resolve, reject) => {
       const stats = fs.statSync(file);
 
@@ -59,7 +61,8 @@ class HttpWrapper {
             'User-Agent': 'Release-Agent',
             'Accept': 'application/vnd.github.v3+json',
             'Content-Length': stats.size,
-            'Content-Type': 'application/gzip'
+            'Content-Type': 'application/gzip',
+            'Authorization': `token ${token}`
           }
         },
         (error, response) => {

--- a/http-wrapper.js
+++ b/http-wrapper.js
@@ -18,7 +18,12 @@ class HttpWrapper {
     return new Promise((resolve, reject) => {
       request.post({
         url: url,
-        headers: {'User-Agent': 'request', 'Content-Type': contentType, 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json'},
+        headers: {
+          'User-Agent': 'request',
+          'Content-Type': contentType,
+          'Authorization': `token ${token}`,
+          'Accept': 'application/vnd.github.v3+json'
+        },
         body: body
       }, (error, response) => {
         if (error) { reject(error); }

--- a/http-wrapper.js
+++ b/http-wrapper.js
@@ -14,11 +14,11 @@ class HttpWrapper {
     });
   }
 
-  makePostRequest(url, body, contentType, token) {
+  makePostRequest(url, body, token, contentType) {
     return new Promise((resolve, reject) => {
       request.post({
         url: url,
-        headers: {'User-Agent': 'request', 'Content-Type': contentType, 'Authorization': `token ${token}`},
+        headers: {'User-Agent': 'request', 'Content-Type': contentType, 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json'},
         body: body
       }, (error, response) => {
         if (error) { reject(error); }


### PR DESCRIPTION
https://sapphire-digital.atlassian.net/browse/PUI-18542

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

- personal access token used in the query param will be deprecated soon
- update access token to be used in the authorization header instead 
- all calls tested and working