### PR TITLE
Fix release download redirect with curl

### DIFF
--- a/download-release.js
+++ b/download-release.js
@@ -90,6 +90,7 @@ class GithubReleaseDownloader {
     console.log('Extracting release...');
     console.log('file type', shell.exec('file release.tar.gz'));
     console.log('file type', shell.exec('cat release.tar.gz'));
+    console.log('curl version', shell.exec('curl --version'));
     shell.exec('tar -zvxf release.tar.gz');
     console.log('checking release folder', shell.exec('ls release'));
   }

--- a/download-release.js
+++ b/download-release.js
@@ -75,7 +75,7 @@ class GithubReleaseDownloader {
     console.log('Downloading release...');
 
     shell.exec(
-      `curl -L -H "Authorization: token ${GH_TOKEN}" -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId} > release.tar.gz`
+      `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
       // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
       // `wget -q --auth-no-challenge --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}?access_token=${GH_TOKEN} -O release.tar.gz`
     );

--- a/download-release.js
+++ b/download-release.js
@@ -74,7 +74,7 @@ class GithubReleaseDownloader {
   download(assetId) {
     console.log('Downloading release...');
     shell.exec(
-      `curl -sL --header "Authorization: token ${GH_TOKEN}" --header 'Accept: application/octet-stream' -H 'Accept-Encoding: gzip' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} > release.tar.gz`
+      `curl -0L --header "Authorization: token ${GH_TOKEN}" --header 'Accept: application/octet-stream' -H 'Accept-Encoding: gzip' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} > release.tar.gz`
     );
   }
 

--- a/download-release.js
+++ b/download-release.js
@@ -98,8 +98,8 @@ class GithubReleaseDownloader {
   unzipRelease() {
     console.log('Extracting release...');
     console.log('file type', shell.exec('file release.tar.gz'));
-    console.log('file type', shell.exec('cat release.tar.gz'));
-    console.log('curl version', shell.exec('curl --version'));
+    // console.log('file type', shell.exec('cat release.tar.gz'));
+    // console.log('curl version', shell.exec('curl --version'));
     shell.exec('tar -zvxf release.tar.gz');
     console.log('checking release folder', shell.exec('ls release'));
   }

--- a/download-release.js
+++ b/download-release.js
@@ -73,10 +73,13 @@ class GithubReleaseDownloader {
 
   download(assetId) {
     console.log('Downloading release...');
-    http.makeGetRequest(
-      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases/assets/' + assetId,
-      {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/octet-stream'}}
-    ).then(res => console.log(res));
+    // http.makeGetRequest(
+    //   'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases/assets/' + assetId,
+    //   {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/octet-stream'}}
+    // ).then(res => console.log(res));
+    shell.exec(
+      `curl -s -H "Authorization: token ${GH_TOKEN}" -H "Accept:application/octet-stream" https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} -w "%{redirect_url}" | xargs curl -so release.tar.gz`
+    )
 
 
     // shell.exec(

--- a/download-release.js
+++ b/download-release.js
@@ -74,8 +74,8 @@ class GithubReleaseDownloader {
   download(assetId) {
     console.log('Downloading release...');
     shell.exec(
-      `curl -sL --header "Authorization: token ${GH_TOKEN}" --header 'Accept: application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} > release.tar.gz`
-    )
+      `curl -sL --header "Authorization: token ${GH_TOKEN}" --header 'Accept: application/octet-stream' -H 'Accept-Encoding: gzip' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} > release.tar.gz`
+    );
   }
 
   makeReleaseDir() {

--- a/download-release.js
+++ b/download-release.js
@@ -75,9 +75,9 @@ class GithubReleaseDownloader {
     console.log('Downloading release...');
 
     shell.exec(
-      `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
+      // `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
       // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
-      // `wget -q --auth-no-challenge --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}?access_token=${GH_TOKEN} -O release.tar.gz`
+      `wget -q --auth-no-challenge --header "Authorization: token ${GH_TOKEN}" --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} -O release.tar.gz`
     );
   }
 

--- a/download-release.js
+++ b/download-release.js
@@ -75,10 +75,9 @@ class GithubReleaseDownloader {
     console.log('Downloading release...');
 
     shell.exec(
-      `curl -0L --header "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github.v3+json" -H 'Accept-Encoding: gzip' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId} > release.tar.gz`
+      `curl -L -H "Authorization: token ${GH_TOKEN}" -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId} > release.tar.gz`
       // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
       // `wget -q --auth-no-challenge --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}?access_token=${GH_TOKEN} -O release.tar.gz`
-
     );
   }
 

--- a/download-release.js
+++ b/download-release.js
@@ -73,12 +73,18 @@ class GithubReleaseDownloader {
 
   download(assetId) {
     console.log('Downloading release...');
+    http.makeGetRequest(
+      'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases/assets/' + assetId,
+      {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/octet-stream'}}
+    ).then(res => console.log(res));
 
-    shell.exec(
-      // `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
-      // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
-      `wget -q --auth-no-challenge --header "Authorization: token ${GH_TOKEN}" --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} -O release.tar.gz`
-    );
+
+    // shell.exec(
+    //   // `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
+    //   // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
+    //   `wget -q --auth-no-challenge --header "Authorization: token ${GH_TOKEN}" --output-document=release.tar.gz --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}`
+
+    // );
   }
 
   makeReleaseDir() {

--- a/download-release.js
+++ b/download-release.js
@@ -85,7 +85,9 @@ class GithubReleaseDownloader {
 
   unzipRelease() {
     console.log('Extracting release...');
+    console.log('file type', shell.exec('file release.tar.gz'));
     shell.exec('tar -zvxf release.tar.gz');
+    console.log('checking release folder', shell.exec('ls release'));
   }
 
 }

--- a/download-release.js
+++ b/download-release.js
@@ -73,21 +73,9 @@ class GithubReleaseDownloader {
 
   download(assetId) {
     console.log('Downloading release...');
-    // http.makeGetRequest(
-    //   'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases/assets/' + assetId,
-    //   {headers: {'User-Agent': 'request', 'Authorization': `token ${GH_TOKEN}`, 'Accept': 'application/octet-stream'}}
-    // ).then(res => console.log(res));
     shell.exec(
       `curl -s -H "Authorization: token ${GH_TOKEN}" -H "Accept:application/octet-stream" https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} -w "%{redirect_url}" | xargs curl -so release.tar.gz`
     )
-
-
-    // shell.exec(
-    //   // `curl -L -H "Accept:application/octet-stream" https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId}?access_token=${GH_TOKEN} > release.tar.gz`
-    //   // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
-    //   `wget -q --auth-no-challenge --header "Authorization: token ${GH_TOKEN}" --output-document=release.tar.gz --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}`
-
-    // );
   }
 
   makeReleaseDir() {
@@ -97,11 +85,7 @@ class GithubReleaseDownloader {
 
   unzipRelease() {
     console.log('Extracting release...');
-    console.log('file type', shell.exec('file release.tar.gz'));
-    // console.log('file type', shell.exec('cat release.tar.gz'));
-    // console.log('curl version', shell.exec('curl --version'));
     shell.exec('tar -zvxf release.tar.gz');
-    console.log('checking release folder', shell.exec('ls release'));
   }
 
 }

--- a/download-release.js
+++ b/download-release.js
@@ -73,8 +73,12 @@ class GithubReleaseDownloader {
 
   download(assetId) {
     console.log('Downloading release...');
+
     shell.exec(
-      `curl -0L --header "Authorization: token ${GH_TOKEN}" --header 'Accept: application/octet-stream' -H 'Accept-Encoding: gzip' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId} > release.tar.gz`
+      `curl -0L --header "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github.v3+json" -H 'Accept-Encoding: gzip' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/${assetId} > release.tar.gz`
+      // `wget --header 'Authorization: token ${GH_TOKEN}' https://api.github.com/repos/mdx-dev/platform-ui-2/releases/assets/31553041`
+      // `wget -q --auth-no-challenge --header='Accept:application/octet-stream' https://api.github.com/repos/${OWNER}/${REPO}/releases/assets/${assetId}?access_token=${GH_TOKEN} -O release.tar.gz`
+
     );
   }
 
@@ -86,6 +90,7 @@ class GithubReleaseDownloader {
   unzipRelease() {
     console.log('Extracting release...');
     console.log('file type', shell.exec('file release.tar.gz'));
+    console.log('file type', shell.exec('cat release.tar.gz'));
     shell.exec('tar -zvxf release.tar.gz');
     console.log('checking release folder', shell.exec('ls release'));
   }


### PR DESCRIPTION
The original curl command wasn't working because the AWS server is on a much older version of curl, where there is a bug with authorization headers. 

The original request (with the auth header) now redirects to another link (without the auth header)