### PR TITLE
chore: Fix lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,11 @@
         "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.2",
   "description": "Creates and downloads github releases",
   "main": "create-release.js",
+  "volta": {
+    "node": "14.18.1",
+    "npm": "6.14.15"
+  },
   "scripts": {
     "test": "node create-release.js <branch> <github_token> <owner> <repo>"
   },
@@ -13,10 +17,8 @@
   ],
   "author": "Nate McDowell",
   "license": "ISC",
-  "devDependencies": {
-    "lodash": "latest"
-  },
   "dependencies": {
+    "lodash": "^4.17.21",
     "request": "^2.83.0"
   }
 }


### PR DESCRIPTION
This PR fixes the Lodash dependency. `latest` isn't a valid version and it should be a regular dependency.